### PR TITLE
Add command to context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,21 @@
         "key": "ctrl+alt+c",
         "mac": "shift+alt+cmd+c"
       }
-    ]
+    ],
+    "menus": {
+      "editor/context/copy": [
+        {
+          "command": "strip-ts-copy.copyAsJs",
+          "when": "editorHasSelection && editorLangId == typescript"
+        }
+      ],
+      "menuBar/edit/copy": [
+        {
+          "command": "strip-ts-copy.copyAsJs",
+          "when": "editorHasSelection && editorLangId == typescript"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run esbuild-base -- --minify",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,6 @@
           "command": "strip-ts-copy.copyAsJs",
           "when": "editorHasSelection && editorLangId == typescript"
         }
-      ],
-      "menuBar/edit/copy": [
-        {
-          "command": "strip-ts-copy.copyAsJs",
-          "when": "editorHasSelection && editorLangId == typescript"
-        }
       ]
     }
   },


### PR DESCRIPTION
Adds the `strip-ts-copy.copyAsJs` command to the `editor/context/copy` and `menuBar/edit/copy` menus when `editorHasSelection && editorLangId == typescript`.

Had to install `esbuild` and change `package.json` `main` to `./out/main.js` to get up and running, not sure if that's an issue on my end or with the repo.